### PR TITLE
Update outdoor_temperature to TMP_A

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Logs are by default written to /var/log/aa-proxy-wican.log
 # Supported AutoPid Values
 - SOC_D - State of charge Displayed
 - SOC - State of charge
-- OUTDOOR_TEMPERATURE - Current outdoor temperature in celcius
+- TMP_A - Current outdoor/ambient temperature in celcius
 
-aa-proxy-wican will use SOC_D if available, otherwise use SOC for the battery percentage.  In addition, if OUTDOOR_TEMPERATURE is available (this is not currently available in vehicle profiles by default) it will also be used.
+aa-proxy-wican will use SOC_D if available, otherwise use SOC for the battery percentage.  In addition, if TMP_A is available it will also be used.
 
 aa-proxy-wican supports additional arguments you may wish to modify.  It can also be run over ssh should you wish to test/debug.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ struct WicanResponse {
     soc: f32,
     #[serde(alias = "SOC_D")]
     soc_d: Option<f32>,
-    #[serde(alias = "OUTDOOR_TEMPERATURE")]
+    #[serde(alias = "TMP_A")]
     outdoor_temperature: Option<f32>,
 }
 


### PR DESCRIPTION
Unsure if it needs to be updated in any other spots, I don't think it does?

But `OUTDOOR_TEMPERATURE` param is already in WiCAN param llist its just called `TMP_A`, for Ambient temperature. I don't think its named the best, but its already used in some profiles, so not ideal to change